### PR TITLE
Remove all actions after turning persist off

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/modes/PersistModule.java
+++ b/core/src/main/java/com/griefcraft/modules/modes/PersistModule.java
@@ -67,6 +67,7 @@ public class PersistModule extends JavaModule {
             lwc.sendLocale(player, "protection.modes.persist.finalize");
         } else {
             player.disableMode(player.getMode(mode));
+            player.removeAllActions();
             lwc.sendLocale(player, "protection.modes.persist.off");
         }
 


### PR DESCRIPTION
_This is a duplicate of [my pull request to the original LWC repository](https://github.com/Hidendra/LWC/pull/946)_

Common source of confusion for players using persist mode; there may still be a lingering action (e.g. `/lock`) after turning persist off. Eventually, they may accidentally apply that action.

# Example
1. Player executes `/lwc mode persist` to turn on persist mode
2. Player executes `/lock` and begins punching many chests to mass lock them
3. Player executes `/lwc mode persist` to turn off persist mode
4. Later, player punches a lockable item (e.g. sign or chest) and accidentally locks it, because of lingering lock action

# Notes

- This change was made via GitHub's file edit interface; therefore it has not been tested for compilation or runtime errors
  - To ensure I used the correct behaviour, I used `DropTransferModule.java` and line 1927 of `LWC.java` for reference
- This suggestion arose after repeated confusion and accidents on our server. I also think this is more convenient behaviour (wouldn't turning persist mode off signal the end of one's mass-locking, for example?)
