### PR TITLE
Fix out-of-the-box build of LWC

### DIFF
--- a/modules/economy/pom.xml
+++ b/modules/economy/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.griefcraft</groupId>
             <artifactId>lwc</artifactId>
-            <version>4.5.0-SNAPSHOT</version>
+            <version>4.6.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The main LWC module's version was updated to 4.6.0, whilst LWC-Economy was still looking for 4.5.0. This broke maven building of the root LWC module.

[See this gist for the Maven error log, before this fix is applied.](https://gist.github.com/RoyCurtis/1bce5e45c504d39cc5aa4881ff650581)

# Notes

* Although I made this change via GitHub's file edit interface, I have tested this same change locally. After applying this fix, `mvn clean package` of the root LWC module finally succeeded. I re-tested this after deleting my `.m2` cache.
* A better long-term fix for this, may be to use Maven's project properties. Perhaps a version token could be defined somewhere, and both LWC's and LWC-Economy's POM file will both refer to it