### PR TITLE
Fix item loss with drop transfer and full inventory

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
+++ b/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
@@ -165,17 +165,29 @@ public class DropTransferModule extends JavaModule {
 
         Block block = world.getBlockAt(protection.getX(), protection.getY(), protection.getZ());
         Map<Integer, ItemStack> remaining = lwc.depositItems(block, itemStack);
+        Map<Integer, ItemStack> forceDrop = null;
 
         if (remaining.size() > 0) {
-            lwc.sendLocale(player, "lwc.dropxfer.chestfull");
-
             for (ItemStack temp : remaining.values()) {
-                bPlayer.getInventory().addItem(temp);
+                // There will only ever be one item to check...
+                forceDrop = bPlayer.getInventory().addItem(temp);
             }
         }
 
+        if (forceDrop != null && forceDrop.size() > 0) {
+            lwc.sendLocale(player, "lwc.dropxfer.bothfull");
+            for (ItemStack drop : remaining.values()) {
+                item.setItemStack(drop);
+            }
+        } else {
+            if (remaining.size() > 0) {
+                lwc.sendLocale(player, "lwc.dropxfer.chestfull");
+            }
+            
+            item.remove();
+        }
+
         bPlayer.updateInventory(); // if they're in the chest and dropping items, this is required
-        item.remove();
     }
 
     @Override

--- a/core/src/main/resources/lang/lwc_en.properties
+++ b/core/src/main/resources/lang/lwc_en.properties
@@ -464,6 +464,7 @@ lwc.worldguard.blacklisted=%red%LWC protections are not allowed in this region!
 lwc.towny.blocked=%red%You can only protect blocks using LWC inside of a Town!
 
 lwc.dropxfer.chestfull=Your chest could not hold all of those items! Have the remaining items back.
+lwc.dropxfer.bothfull=Neither you nor your chest could hold all of those items! The remaining items have dropped as normal.
 lwc.dropxfer.acrossworlds=%red%You cannot drop transfer items across different worlds!
 
 lwc.unlock.noselection=%red%Nothing selected. Open a locked password protection first.


### PR DESCRIPTION
When a drop transfer chest is full, the drop transfer will attempt to return excess items to the player. However, this doesn't account for when the player's inventory also becomes full (e.g. because of other items in the ground).

This situation can arise if a player holds an item under their cursor, and suddenly their inventory becomes full. The item under the cursor becomes lost, as LWC destroys it.

This PR fixes this bug by checking if the player's inventory failed to accept part or all of the dropped item. If so, the item is forcefully dropped into the world.

[Video reproduction of item loss bug, before this fix is applied](http://vanderprot.gamealition.com/img/7835e.mp4)

# Testing

## Server

* Local PaperSpigot 1.11.2 testing server
* `git-Paper-1052 (MC: 1.11.2) (Implementing API version 1.11.2-R0.1-SNAPSHOT)` (4 versions behind)
* 2 plugins: [EssentialsX build 467](https://ci.drtshock.net/job/EssentialsX/467/) and [LWC (built by IntelliJ)](http://i.imgur.com/l6wQJVb.png)

## Checklist

- [x] No compilation errors or run-time exceptions
- [x] Drop transfer works as normal when target chest has space
- [x] Drop transfer cancels as normal when target chest is out of space
- [x] Drop transfer forcefully drops items when target chest and player is out of space
- [x] No item duplication from forced drops if target chest fills up
  * This was tested by filling a chest and my inventory with diamond swords. One chest slot was changed to hold 48 diamonds, and in my inventory were 32 diamonds, and on the ground was one more diamond sword. I clicked my 32 diamonds, thus picking up the ground sword, then attempted to drop the diamonds. LWC correctly filled the chest diamonds up to 64, and the force drop on the ground became 16 diamonds, as expected.
- [x] No item duplication from forced drops if player's inventory fills up
  * This was tested by filling a chest and my inventory with diamond swords. One slot in my inventory was changed to 64 diamonds, and on the ground was 16 diamonds. I clicked my 64 diamonds, thus picking up the ground 16 diamonds, then attempted to drop the 64 diamonds. LWC correctly filled my diamonds up to 64, and the force drop on the ground became 16 diamonds, as expected.

# Notes

* This bug was discovered by etherealflaim, a player on our survival server. [The original bug notice can be found here.](https://forums.gamealition.com/viewtopic.php?f=1&t=20&start=60#p2234)
* This needed a new locale message to explain the drop action to the player. As English is my only language, I could not provide strings in other languages. Sorry!