### PR TITLE
Add hopper protection that is not based on the InventoryMoveItemEvent

### DIFF
--- a/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -46,6 +46,7 @@ import org.bukkit.block.DoubleChest;
 import org.bukkit.block.Hopper;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -84,6 +85,10 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onMoveItem(InventoryMoveItemEvent event) {
+        if (plugin.getLWC().useAlternativeHopperProtection()
+                && !(event.getSource().getHolder() instanceof HopperMinecart || event.getDestination().getHolder() instanceof HopperMinecart))
+            return;
+
         if (plugin.getLWC().useFastHopperProtection() && event.getSource().getHolder() instanceof Hopper)
             return;
 

--- a/core/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/core/src/main/java/com/griefcraft/lwc/LWC.java
@@ -210,11 +210,17 @@ public class LWC {
      */
     private boolean fastHoppers;
 
+    /**
+     * Whether alternative-hopper-protection is enabled
+     */
+    private boolean alternativeHoppers;
+
     public LWC(LWCPlugin plugin) {
         this.plugin = plugin;
         LWC.instance = this;
         configuration = Configuration.load("core.yml");
         fastHoppers = configuration.getBoolean("optional.fastHopperProtection", false);
+        alternativeHoppers = configuration.getBoolean("optional.alternativeHopperProtection", false);
         protectionCache = new ProtectionCache(this);
         backupManager = new BackupManager();
         moduleLoader = new ModuleLoader(this);
@@ -1903,6 +1909,7 @@ public class LWC {
         protectionConfigurationCache.clear();
         Configuration.reload();
         fastHoppers = configuration.getBoolean("optional.fastHopperProtection", false);
+        alternativeHoppers = configuration.getBoolean("optional.alternativeHopperProtection", false);
         moduleLoader.dispatchEvent(new LWCReloadEvent());
     }
 
@@ -2053,8 +2060,14 @@ public class LWC {
     /**
      * @return true if fast hopper protection is enabled
      */
-    public boolean useFastHopperProtection()
-    {
+    public boolean useFastHopperProtection() {
         return fastHoppers;
+    }
+
+    /**
+     * @return true if alternative hopper protection is enabled
+     */
+    public boolean useAlternativeHopperProtection() {
+        return alternativeHoppers;
     }
 }

--- a/core/src/main/resources/config/core.yml
+++ b/core/src/main/resources/config/core.yml
@@ -77,6 +77,11 @@ optional:
     # protected hopper, but doesn't apply to a hopper pulling from a protected chest
     fastHopperProtection: false
 
+    # Disable protection checks for any item moves except for hopper minecarts. Protection against
+    # hoppers is now done by checking for protections of the containers that the hopper is pointing
+    # into and that are above the hopper that the player placing the block doesn't have access to.
+    alternativeHopperProtection: false
+
 # Database information for LWC
 database:
 


### PR DESCRIPTION
This alternative protection mode checks the container above and the one a hopper is pointing into when a hopper is placed. Hopper minecarts still rely on the move item even though as they obviously can be moved above/under a protected container.