### PR TITLE
Store block type to id mapping to fix compatibility with 1.13.

### DIFF
--- a/core/src/main/java/com/griefcraft/cache/MaterialCache.java
+++ b/core/src/main/java/com/griefcraft/cache/MaterialCache.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 Max Lee (Phoenix616). All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and contributors and should not be interpreted as representing official policies,
+ * either expressed or implied, of anybody else.
+ */
+
+package com.griefcraft.cache;
+
+
+import com.griefcraft.lwc.LWC;
+import org.bukkit.Material;
+
+public class MaterialCache {
+
+    /**
+     * The LWC instance this set belongs to
+     */
+    private final LWC lwc;
+
+    /**
+     * Map numeric IDs to types
+     */
+    private final LRUCache<Integer, Material> idToType;
+
+    /**
+     * Map numeric types to numeric Ids
+     */
+    private final LRUCache<Material, Integer> typeToId;
+
+    /**
+     * The capacity of the cache
+     */
+    private int capacity;
+
+    public MaterialCache(LWC lwc) {
+        this.lwc = lwc;
+        this.capacity = lwc.getConfiguration().getInt("core.cacheSize", 10000);
+
+        this.idToType = new LRUCache<>(capacity);
+        this.typeToId = new LRUCache<>(capacity);
+    }
+
+    /**
+     * Gets the default capacity of the cache
+     *
+     * @return
+     */
+    public int capacity() {
+        return capacity;
+    }
+
+    /**
+     * Clears the entire protection cache
+     */
+    public void clear() {
+        // remove hard refs
+        idToType.clear();
+        typeToId.clear();
+    }
+
+    /**
+     * Cache a mapping
+     *
+     * @param material
+     */
+    public void addTypeId(Material material, int id) {
+        typeToId.put(material, id);
+        idToType.put(id, material);
+    }
+
+    /**
+     * Remove the material from the cache
+     *
+     * @param material
+     */
+    public void removeType(Material material) {
+        Integer id = typeToId.remove(material);
+        if (id != null) {
+            idToType.remove(id);
+        }
+    }
+
+    /**
+     * Remove the material from the cache
+     *
+     * @param id
+     */
+    public void removeType(int id) {
+        Material type = idToType.remove(id);
+        if (type != null) {
+            typeToId.remove(type);
+        }
+    }
+
+    /**
+     * Get the ID of a type
+     *
+     * @param type
+     * @return The cached ID or -1 if not found
+     */
+    public int getId(Material type) {
+        Integer id = typeToId.get(type);
+        return id != null ? id : -1;
+    }
+
+    /**
+     * Get the Material type of an ID
+     *
+     * @param id
+     * @return The cached Material type or null if not found
+     */
+    public Material getType(int id) {
+        return idToType.get(id);
+    }
+}

--- a/core/src/main/java/com/griefcraft/io/Backup.java
+++ b/core/src/main/java/com/griefcraft/io/Backup.java
@@ -28,6 +28,7 @@
 
 package com.griefcraft.io;
 
+import com.griefcraft.lwc.LWC;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -177,7 +178,7 @@ public class Backup {
                 short damage = inputStream.readShort();
 
                 // Create the stack
-                Material itemType = LegacyMaterials.getNewMaterial(itemId);
+                Material itemType = LWC.getInstance().getPhysicalDatabase().getType(itemId);
                 ItemStack itemStack = new ItemStack(itemType, amount, damage);
 
                 // add it to the block
@@ -240,7 +241,7 @@ public class Backup {
                 ItemStack stack = entry.getValue();
 
                 outputStream.writeShort(slot);
-                outputStream.writeShort(LegacyMaterials.getOldId(stack.getType()));
+                outputStream.writeShort(LWC.getInstance().getPhysicalDatabase().getTypeId(stack.getType()));
                 outputStream.writeShort(stack.getAmount());
                 outputStream.writeShort(stack.getDurability());
             }

--- a/core/src/main/java/com/griefcraft/io/RestorableBlock.java
+++ b/core/src/main/java/com/griefcraft/io/RestorableBlock.java
@@ -109,7 +109,7 @@ public class RestorableBlock implements Restorable {
                 Block block = bworld.getBlockAt(x, y, z);
 
                 // Begin screwing with shit :p
-                block.setType(LegacyMaterials.getNewMaterial(id));
+                block.setType(lwc.getPhysicalDatabase().getType(id));
                 block.getState().setRawData((byte) data);
                 block.getState().update();
 
@@ -150,7 +150,7 @@ public class RestorableBlock implements Restorable {
         }
 
         RestorableBlock rblock = new RestorableBlock();
-        rblock.id = LegacyMaterials.getOldId(block.getType());
+        rblock.id = LWC.getInstance().getPhysicalDatabase().getTypeId(block.getType());
         rblock.world = block.getWorld().getName();
         rblock.x = block.getX();
         rblock.y = block.getY();

--- a/core/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
+++ b/core/src/main/java/com/griefcraft/listeners/LWCBlockListener.java
@@ -185,7 +185,7 @@ public class LWCBlockListener implements Listener {
 
         if (protection == null) {
             return;
-        } else if (!blockMatches(protection.getBlockId(), block.getType())) {
+        } else if (protection.getBlockType() != block.getType()) {
             // this block is no longer the block that's supposed to be protected
             protection.remove();
             return;
@@ -204,7 +204,7 @@ public class LWCBlockListener implements Listener {
                 // if they destroyed the protected block we want to move it aye?
                 if (lwc.blockEquals(protection.getBlock(), block)) {
                     // correct the block
-                    protection.setBlockId(LegacyMaterials.getOldId(block.getType()));
+                    protection.setBlockId(lwc.getPhysicalDatabase().getTypeId(block.getType()));
                     protection.setX(doubleChest.getX());
                     protection.setY(doubleChest.getY());
                     protection.setZ(doubleChest.getZ());
@@ -245,7 +245,7 @@ public class LWCBlockListener implements Listener {
      * @return 
      */
     static boolean blockMatches(int blockID, Material blockMat) {
-        return LegacyMaterials.getNewMaterial(blockID) == blockMat;
+        return LWC.getInstance().getPhysicalDatabase().getType(blockID) == blockMat;
     }
 
     @EventHandler

--- a/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -283,7 +283,7 @@ public class LWCPlayerListener implements Listener {
             Set<String> actions = lwcPlayer.getActionNames();
             Protection protection = lwc.findProtection(block.getLocation());
             
-            if (protection != null && !LWCBlockListener.blockMatches(protection.getBlockId(), block.getType())) {
+            if (protection != null && protection.getBlockType() != block.getType()) {
                 // this block is no longer the block that's supposed to be protected
                 protection.remove();
                 return;

--- a/core/src/main/java/com/griefcraft/model/Protection.java
+++ b/core/src/main/java/com/griefcraft/model/Protection.java
@@ -608,7 +608,7 @@ public class Protection {
             return false;
         }
 
-        return LegacyMaterials.getNewMaterial(blockId) == block.getType();
+        return getBlockType() == block.getType();
     }
 
     public JSONObject getData() {
@@ -617,6 +617,10 @@ public class Protection {
 
     public int getBlockId() {
         return blockId;
+    }
+
+    public Material getBlockType() {
+        return LWC.getInstance().getPhysicalDatabase().getType(blockId);
     }
 
     public String getPassword() {

--- a/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
+++ b/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
@@ -207,8 +207,8 @@ public class DropTransferModule extends JavaModule {
         if (!canAccess) {
             lwc.sendLocale(player, "protection.interact.dropxfer.noaccess");
         } else {
-            int blockId = protection.getBlockId();
-            if (blockId != Material.CHEST.getId() && blockId != Material.TRAPPED_CHEST.getId()) {
+            Material blockType = protection.getBlockType();
+            if (blockType != Material.CHEST && blockType != Material.TRAPPED_CHEST) {
                 lwc.sendLocale(player, "protection.interact.dropxfer.notchest");
                 player.removeAllActions();
                 event.setResult(Result.CANCEL);

--- a/core/src/main/java/com/griefcraft/sql/Column.java
+++ b/core/src/main/java/com/griefcraft/sql/Column.java
@@ -52,6 +52,11 @@ class Column {
     private boolean primary = false;
 
     /**
+     * If the content should be unique
+     */
+    private boolean unique = false;
+
+    /**
      * The table this column is assigned to
      */
     private Table table;
@@ -111,5 +116,13 @@ class Column {
 
     public boolean shouldAutoIncrement() {
         return autoIncrement;
+    }
+
+    public void setUnique(boolean unique) {
+        this.unique = unique;
+    }
+
+    public boolean isUnique() {
+        return unique;
     }
 }

--- a/core/src/main/java/com/griefcraft/sql/PhysDB.java
+++ b/core/src/main/java/com/griefcraft/sql/PhysDB.java
@@ -31,7 +31,9 @@ package com.griefcraft.sql;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import com.griefcraft.cache.LRUCache;
@@ -47,6 +49,7 @@ import com.griefcraft.util.LegacyMaterials;
 import com.griefcraft.util.UUIDRegistry;
 import com.griefcraft.util.config.Configuration;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.json.simple.JSONArray;
@@ -210,7 +213,7 @@ public class PhysDB extends Database {
     }
 
     public int getProtectionCount(String player, Material blockType) {
-        return getProtectionCount(player, LegacyMaterials.getOldId(blockType));
+        return getProtectionCount(player, getTypeId(blockType));
     }
 
     /**
@@ -332,6 +335,19 @@ public class PhysDB extends Database {
             protections.add(column);
         }
 
+        Table types = new Table(this, "types");
+        {
+            column = new Column("id");
+            column.setType("INTEGER");
+            column.setPrimary(true);
+            types.add(column);
+
+            column = new Column("name");
+            column.setType("VARCHAR(255)");
+            column.setUnique(true);
+            types.add(column);
+        }
+
         Table history = new Table(this, "history");
         {
             column = new Column("id");
@@ -390,6 +406,7 @@ public class PhysDB extends Database {
         }
 
         protections.execute();
+        types.execute();
         history.execute();
         internal.execute();
 
@@ -489,6 +506,55 @@ public class PhysDB extends Database {
                 lwc.log("Added Trapped Chests to core.yml as default protectable (ENABLED & AUTO REGISTERED)");
                 lwc.log("Trapped chests are nearly the same as reg chests but can light up! They can also be double chests.");
                 lwc.log("If you DO NOT want this as protected, simply remove it from core.yml! (search/look for trapped_chests under protections -> blocks");
+            }
+
+            incrementDatabaseVersion();
+        }
+
+        if (databaseVersion == 6) {
+            lwc.log("Building Material type ID mapping... This might take a while!");
+            int checked = 0;
+            int added = 0;
+            // materials to add after with auto increment IDs
+            Set<Material> addLater = EnumSet.noneOf(Material.class);
+            for (Material material : Material.values()) {
+                checked++;
+                if (checked % 100 == 0) {
+                    lwc.log(checked + "/" + Material.values().length + " checked...");
+                }
+                if (material.isLegacy()) {
+                    setTypeId(material.name(), material.getId());
+                    LWC.getInstance().getMaterialCache().addTypeId(material, material.getId());
+                } else {
+                    Material legacy = Bukkit.getUnsafe().toLegacy(material);
+                    if (legacy != null) {
+                        String name = legacy.name().substring(Material.LEGACY_PREFIX.length());
+                        // Check if names are similar. This should avoid issues with blocks that used data values before.
+                        if (name.equals(material.name()) || name.contains(material.name()) || material.name().contains(name)) {
+                            added++;
+                            if (added % 100 == 0) {
+                                lwc.log(added + "/" + Material.values().length + " added...");
+                            }
+                            setTypeId(material.name(), legacy.getId());
+                            LWC.getInstance().getMaterialCache().addTypeId(material, legacy.getId());
+                        } else {
+                            // if not similar add them later
+                            addLater.add(material);
+                        }
+                    } else {
+                        // no legacy ID found, add it later
+                        addLater.add(material);
+                    }
+                }
+            }
+
+            // add using auto increment IDs
+            for (Material material : addLater) {
+                added++;
+                if (added % 100 == 0) {
+                    lwc.log(added + "/" + Material.values().length + " added...");
+                }
+                addType(material);
             }
 
             incrementDatabaseVersion();
@@ -1117,7 +1183,7 @@ public class PhysDB extends Database {
     }
 
     public Protection registerProtection(Material blockType, Protection.Type type, String world, String player, String data, int x, int y, int z) {
-        return registerProtection(LegacyMaterials.getOldId(blockType), type, world, player, data, x, y, z);
+        return registerProtection(getTypeId(blockType), type, world, player, data, x, y, z);
     }
 
     @Deprecated
@@ -1173,6 +1239,125 @@ public class PhysDB extends Database {
         }
 
         return null;
+    }
+
+    /**
+     * Set the type id in the types table
+     *
+     * @param type  The material type name
+     * @param id    The numeric ID to use in the protections table
+     */
+    private void setTypeId(String type, int id) {
+        try {
+            PreparedStatement statement = prepare("INSERT INTO " + prefix +"types (id, name) VALUES (?, ?)");
+            statement.setInt(1, id);
+            statement.setString(2, type);
+
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            // Already exists
+            try {
+                PreparedStatement statement = prepare("UPDATE " + prefix + "types SET id = ? WHERE name = ?");
+                statement.setInt(1, id);
+                statement.setString(2, type);
+
+                statement.executeUpdate();
+            } catch (SQLException ex) {
+                // Something bad went wrong
+                printException(ex);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Add a type. If it's already cached it will return the cached one instead of adding a new one
+     *
+     * @param type  The material type
+     * @return      The generated or existing ID of that type; -2 if an error occured
+     */
+    private int addType(Material type) {
+        try {
+            PreparedStatement statement = prepare("INSERT INTO " + prefix +"types (name) VALUES (?)", true);
+            statement.setString(1, type.name());
+
+            statement.executeUpdate();
+            ResultSet set = statement.getGeneratedKeys();
+            int id = -1;
+            if (set.next()) {
+                id = set.getInt(1);
+                LWC.getInstance().getMaterialCache().addTypeId(type, id);
+            }
+            set.close();
+            return id;
+        } catch (SQLException e) {
+            return -1;
+            // Already exists
+        }
+    }
+
+    /**
+     * Get the internal database ID of a material
+     *
+     * @param type  The material to get the ID for
+     * @return      The ID or -1 if none was found
+     */
+    public int getTypeId(Material type) {
+        int id = LWC.getInstance().getMaterialCache().getId(type);
+        if (id > -1) {
+            return id;
+        }
+        try {
+            PreparedStatement statement = prepare("SELECT id FROM " + prefix + "types WHERE name = ?");
+            statement.setString(1, type.name());
+
+            ResultSet set = statement.executeQuery();
+
+            if (set.next()) {
+                id = set.getInt("id");
+            }
+
+            set.close();
+        } catch (SQLException e) {
+            printException(e);
+        }
+        if (id > -1) {
+            LWC.getInstance().getMaterialCache().addTypeId(type, id);
+        } else {
+            id = addType(type);
+        }
+        return id;
+    }
+
+    /**
+     * Get the material from the internal database ID
+     *
+     * @param id    The ID to get the type for
+     * @return      The ID or -1 if none was found
+     */
+    public Material getType(int id) {
+        Material type = LWC.getInstance().getMaterialCache().getType(id);
+        if (type != null) {
+            return type;
+        }
+        try {
+            PreparedStatement statement = prepare("SELECT name FROM " + prefix + "types WHERE id = ?");
+            statement.setInt(1, id);
+
+            ResultSet set = statement.executeQuery();
+
+            if (set.next()) {
+                type = Material.getMaterial(set.getString("name"));
+            }
+
+            set.close();
+        } catch (SQLException e) {
+            printException(e);
+        }
+        if (type != null) {
+            LWC.getInstance().getMaterialCache().addTypeId(type, id);
+        }
+        return type;
     }
 
     /**

--- a/core/src/main/java/com/griefcraft/sql/Table.java
+++ b/core/src/main/java/com/griefcraft/sql/Table.java
@@ -107,6 +107,10 @@ public class Table {
                 buffer.append("PRIMARY KEY ");
             }
 
+            if (column.isUnique()) {
+                buffer.append("UNIQUE ");
+            }
+
             if (column.shouldAutoIncrement() && database.getType() == Type.MySQL) {
                 buffer.append("AUTO_INCREMENT ");
             }


### PR DESCRIPTION
This solves issues with legacy materials not being available at runtime (which breaks the plugin in 1.13) and them potentially getting removed in the future.

On first startup it will create a new types table and tries to populate it with the legacy type IDs where possible. For the new/non-matchable types it will generate arbitrary ID numbers.

I didn't move Protections over to use a Material field completely but I added a getBlockType convenience method. Maybe we need to introduce a BlockProtection and a EntityProtection class in the future to properly support entity protection in a non-hacky way. Protection would then have to change to use a generic for the type of protection and getType would return the type based on the generic? BUt that's for a future, this is just supposed to make it work with old databases on 1.13.