### PR TITLE
Fix doors not closing when open

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/doors/DoorsModule.java
+++ b/core/src/main/java/com/griefcraft/modules/doors/DoorsModule.java
@@ -213,11 +213,11 @@ public class DoorsModule extends JavaModule {
             Block topHalf = door.getRelative(BlockFace.UP);
             if (topHalf.getBlockData() instanceof Door) {
                 Door topData = (Door) topHalf.getBlockData();
-                topData.setOpen(true);
+                topData.setOpen(!topData.isOpen());
                 topHalf.setBlockData(topData);
             }
 
-            data.setOpen(true);
+            data.setOpen(!data.isOpen());
             door.setBlockData(data);
 
             // Play the door open/close sound


### PR DESCRIPTION
I guess that this bug just slipped past someone.
It fixes protected iron doors not closing when they are open and any double doors not closing when they are open.